### PR TITLE
Move node-sass to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "sass-inline-image",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "inline images as base64",
   "main": "index.js",
   "scripts": {},
   "author": "Joseph Clay",
   "license": "MIT",
-  "dependencies": {
-    "node-sass": "^3.3.3"
+  "repository": "https://github.com/JosephClay/sass-inline-image",
+  "peerDependencies": {
+    "node-sass": "*"
   }
 }


### PR DESCRIPTION
To fix support for gulp-sass@3.*